### PR TITLE
requests to single pool, conn inside function parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,19 +418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,16 +637,13 @@ version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04001f23ba8843dc315804fa324000376084dfb1c30794ff68dd279e6e5696d5"
 dependencies = [
- "bigdecimal",
  "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
  "itoa",
- "num-bigint",
- "num-integer",
- "num-traits",
  "pq-sys",
+ "r2d2",
  "uuid",
 ]
 
@@ -1254,12 +1238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,29 +1341,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1586,6 +1545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/properties/Cargo.toml
+++ b/properties/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 dotenvy = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-diesel = { version = "2.2.0", features = ["postgres", "uuid", "chrono", "numeric"] }
+diesel = { version = "2.2.0", features = ["postgres", "r2d2", "uuid", "chrono"] }
 diesel_migrations = "*"
 uuid = { version = "1.4", features = ["v4"] }
 chrono = "*"

--- a/properties/src/dal/repository.rs
+++ b/properties/src/dal/repository.rs
@@ -1,5 +1,7 @@
+use diesel::PgConnection;
+
 use super::sch_models::PropertyWithDetails;
 
 pub trait PropertiesRepository {
-    fn fetch_top_properties(&self) -> Vec<PropertyWithDetails>;
+    fn fetch_top_properties(conn: &mut PgConnection) -> Vec<PropertyWithDetails>;
 }

--- a/properties/src/main.rs
+++ b/properties/src/main.rs
@@ -39,6 +39,8 @@ async fn main() -> std::io::Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     run_migrations();
 
+    let pool = initialize_db_pool();  
+
     HttpServer::new(move || {
         let cors = Cors::default()
             .allow_any_origin()
@@ -49,8 +51,6 @@ async fn main() -> std::io::Result<()> {
         #[openapi(paths(routes::fetch_boosted_properties), components(schemas(dto::property_summary::PropertySummary)))]
         struct ApiDoc;
         let openapi = ApiDoc::openapi();
-
-        let pool = initialize_db_pool();    
 
         App::new()
             .app_data(web::Data::new(pool.clone()))

--- a/properties/src/main.rs
+++ b/properties/src/main.rs
@@ -4,8 +4,7 @@ mod dto;
 
 use actix_cors::Cors;
 use actix_web::{web, App, HttpServer};
-use dal::db_operations::PgProperties;
-use diesel::prelude::*;
+use diesel::{prelude::*, r2d2};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use dotenvy::dotenv;
 use env_logger::Env;
@@ -14,8 +13,10 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+type DbPool = r2d2::Pool<r2d2::ConnectionManager<PgConnection>>;
 
-fn do_migrations() {
+/// Run diesel migrations at compile-time
+fn run_migrations() {
     dotenv().ok();
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let mut conn = PgConnection::establish(&url).expect("Failed to establish connection");
@@ -23,16 +24,20 @@ fn do_migrations() {
         .expect("Couldn't migrate tables");
 }
 
+/// Initialize database connection pool based on `DATABASE_URL` environment variable.
+fn initialize_db_pool() -> DbPool {
+    let conn_spec = std::env::var("DATABASE_URL").expect("DATABASE_URL should be set");
+    let manager = r2d2::ConnectionManager::<PgConnection>::new(conn_spec);
+    r2d2::Pool::builder()
+        .build(manager)
+        .expect("database URL should be valid path to postgresql server")
+}
+
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-
-    dotenv().ok();
-    let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-
-    do_migrations();
-
-    let repo: PgProperties = PgProperties::new(url.clone());
+    run_migrations();
 
     HttpServer::new(move || {
         let cors = Cors::default()
@@ -43,10 +48,12 @@ async fn main() -> std::io::Result<()> {
         #[derive(OpenApi)]
         #[openapi(paths(routes::fetch_boosted_properties), components(schemas(dto::property_summary::PropertySummary)))]
         struct ApiDoc;
-        let openapi = ApiDoc::openapi();        
+        let openapi = ApiDoc::openapi();
+
+        let pool = initialize_db_pool();    
 
         App::new()
-            .app_data(web::Data::new(repo.clone()))
+            .app_data(web::Data::new(pool.clone()))
             .service(
                 SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-docs/openapi.json", openapi.clone()),
             )


### PR DESCRIPTION
1. single pool implemented for all requests in the service
2. conn is now inside the function parameters to use the same pool
3. db_operations simplified

ref.
//! Diesel v2 is not an async library, so we have to execute queries in `web::block` closures which
//! offload blocking code (like Diesel's) to a thread-pool in order to not block the server.

https://actix.rs/docs/databases